### PR TITLE
Add override for section link template

### DIFF
--- a/tests/test_template_override.py
+++ b/tests/test_template_override.py
@@ -1,0 +1,45 @@
+import unittest
+
+from wikitextprocessor import Wtp
+
+from wiktextract.template_override import template_override_fns
+
+
+class TemplateOverrideTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.wtp = Wtp(lang_code="en", template_override_funcs=template_override_fns)
+        self.wtp.start_page("TemplateOverride")
+
+    def tearDown(self) -> None:
+        self.wtp.close_db_conn()
+
+    def test_section_link_two_params(self) -> None:
+        result = self.wtp.expand(
+            "{{section link|Wiktionary:Entry layout|Translations}}"
+        )
+        self.assertEqual(
+            result,
+            "[[Wiktionary:Entry layout#Translations|Translations]]",
+        )
+
+    def test_section_link_single_param_with_anchor(self) -> None:
+        result = self.wtp.expand(
+            "{{section link|Wiktionary:Entry layout#Translations}}"
+        )
+        self.assertEqual(
+            result,
+            "[[Wiktionary:Entry layout#Translations|Translations]]",
+        )
+
+    def test_section_link_named_parameters(self) -> None:
+        result = self.wtp.expand(
+            "{{section link|page=Wiktionary:Entry layout|section=Translations|display=Read more}}"
+        )
+        self.assertEqual(
+            result,
+            "[[Wiktionary:Entry layout#Translations|Read more]]",
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a simplified override for the English {{section link}} template to avoid Lua expansion failures
- add regression tests that exercise the override with positional and named arguments

## Testing
- PYTHONPATH=src pytest tests/test_template_override.py

------
https://chatgpt.com/codex/tasks/task_e_68e14ab23d9c8331abb48cbf80366c54