### PR TITLE
Enable strict REST example boundary checks by default

### DIFF
--- a/docs/PR_lay_fix.md
+++ b/docs/PR_lay_fix.md
@@ -1,0 +1,41 @@
+Title
+-----
+REST example breadcrumb enforcement default-on for "lay" regression
+
+Summary
+-------
+- Default the REST parser's strict sense-boundary matching to on via `WIKTEXTRACT_STRICT_SENSE_BOUNDARY` while retaining a fallback guard.
+- Extend `tools/repro_lay.py` to fetch live REST HTML for arbitrary titles and accept fixture overrides for the "before" reproduction.
+- Add a helper report to quantify part-of-speech changes for targeted example texts across boundary toggle runs.
+
+Root cause
+----------
+- REST extraction previously fell back to the most recent sense when breadcrumb matching failed, which allowed the "pullet" citation to drift into the noun section when the guard was disabled.
+- The strict matching logic landed behind a flag and the reproduction script only handled the bespoke "lay" fixture, preventing wider smoke checks.
+
+Fix
+----
+- Normalize the strict-boundary environment flag handling and ensure the guard is enabled by default unless explicitly switched off.
+- Broaden the reproduction script with word selection, live REST fetching, and fixture overrides so we can validate both the patched and legacy behaviours.
+- Provide an automated comparison report that counts example POS changes for a curated word list across pre/post runs.
+
+Testing
+-------
+- `PYTHONPATH=src python tools/repro_lay.py --out-a outA.jsonl --out-b outB.jsonl --contains "I never kill a pullet"`
+- `PYTHONPATH=src python tools/compare_jsonl_examples.py --a outA.jsonl --b outB.jsonl --contains "I never kill a pullet"`
+- `PYTHONPATH=src python tools/inspect_jsonl.py --jsonl outB.jsonl --word lay | head -n 60`
+- `WIKTEXTRACT_STRICT_SENSE_BOUNDARY=0 PYTHONPATH=src python tools/repro_lay.py --out-a outA_off.jsonl --out-b outB_off.jsonl --contains "I never kill a pullet"`
+- `WIKTEXTRACT_STRICT_SENSE_BOUNDARY=0 PYTHONPATH=src python tools/compare_jsonl_examples.py --a outA_off.jsonl --b outB_off.jsonl --contains "I never kill a pullet"`
+- `WIKTEXTRACT_STRICT_SENSE_BOUNDARY=0 PYTHONPATH=src python tools/inspect_jsonl.py --jsonl outB_off.jsonl --word lay | head -n 60`
+- `PYTHONPATH=src python tools/report_pos_changes.py --old old/merged.jsonl --new new/merged.jsonl --words words.txt`
+
+Risk/Impact
+-----------
+- Low: the stricter default only affects example attachment when breadcrumbs disagree, and the toggle plus smoke report cover multi-POS regressions.
+
+変更ファイル
+------------
+- src/wiktextract/rest_parser.py
+- tools/repro_lay.py
+- tools/report_pos_changes.py
+- docs/PR_lay_fix.md

--- a/tools/report_pos_changes.py
+++ b/tools/report_pos_changes.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Report example POS changes between two JSONL extractions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, Set
+
+
+ExampleMap = Dict[str, Dict[str, Set[str]]]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare two JSONL dumps and report how many example sentences "
+            "changed the part-of-speech they are attached to for selected "
+            "words."
+        )
+    )
+    parser.add_argument("--old", required=True, help="JSONL file with strict boundary disabled")
+    parser.add_argument("--new", required=True, help="JSONL file with strict boundary enabled")
+    parser.add_argument("--words", required=True, help="Path to newline-delimited word list")
+    return parser.parse_args()
+
+
+def _load_word_list(path: Path) -> list[str]:
+    words: list[str] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            word = line.strip()
+            if word:
+                words.append(word)
+    return words
+
+
+def _load_examples(path: Path) -> ExampleMap:
+    mapping: ExampleMap = defaultdict(lambda: defaultdict(set))
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            data = json.loads(line)
+            word = data.get("word") or ""
+            pos = data.get("pos") or ""
+            if not word or not pos:
+                continue
+            for sense in data.get("senses", []) or []:
+                examples: Iterable[Mapping[str, str]] = sense.get("examples", []) or []
+                for example in examples:
+                    text = (example.get("text") or "").strip()
+                    if not text:
+                        continue
+                    mapping[word][text].add(pos)
+    return mapping
+
+
+def _count_changes(word: str, old_map: ExampleMap, new_map: ExampleMap) -> tuple[int, int, int]:
+    old_examples = old_map.get(word, {})
+    new_examples = new_map.get(word, {})
+    changed = 0
+    all_texts = set(old_examples) | set(new_examples)
+    for text in all_texts:
+        if old_examples.get(text, set()) != new_examples.get(text, set()):
+            changed += 1
+    return changed, len(old_examples), len(new_examples)
+
+
+def main() -> None:
+    args = parse_args()
+    old_path = Path(args.old)
+    new_path = Path(args.new)
+    words_path = Path(args.words)
+
+    words = _load_word_list(words_path)
+    old_map = _load_examples(old_path)
+    new_map = _load_examples(new_path)
+
+    header = f"{'Word':<10}{'Changed':>10}{'OldUnique':>12}{'NewUnique':>12}"
+    print(header)
+    print("-" * len(header))
+    for word in words:
+        changed, old_total, new_total = _count_changes(word, old_map, new_map)
+        print(f"{word:<10}{changed:>10}{old_total:>12}{new_total:>12}")
+
+
+if __name__ == "__main__":
+    main()

--- a/words.txt
+++ b/words.txt
@@ -1,0 +1,7 @@
+set
+run
+lie
+lead
+fast
+fair
+lay


### PR DESCRIPTION
## Summary
- default the REST HTML parser to strict breadcrumb matching while still allowing an explicit opt-out flag
- expand `tools/repro_lay.py` so the lay regression script can target arbitrary words and fixtures
- add `tools/report_pos_changes.py` and supporting documentation for reporting example POS changes

## Testing
- `PYTHONPATH=src python tools/repro_lay.py --out-a outA.jsonl --out-b outB.jsonl --contains "I never kill a pullet"`
- `WIKTEXTRACT_STRICT_SENSE_BOUNDARY=0 PYTHONPATH=src python tools/repro_lay.py --out-a outA_off.jsonl --out-b outB_off.jsonl --contains "I never kill a pullet"`
- `PYTHONPATH=src python tools/report_pos_changes.py --old old/merged.jsonl --new new/merged.jsonl --words words.txt`


------
https://chatgpt.com/codex/tasks/task_e_68e1ced8a8708331b9ae79f0db5a2532