### PR TITLE
Use passage text for quotes with non-English origtext

### DIFF
--- a/src/wiktextract/extractor/en/example.py
+++ b/src/wiktextract/extractor/en/example.py
@@ -88,6 +88,15 @@ def extract_example_list_item(
 def extract_quote_templates(
     wxr: WiktextractContext, node: TemplateNode, sense_data: SenseData
 ) -> ExampleData:
+    origtext_lang = None
+    origtext_param = node.template_parameters.get("origtext")
+    if origtext_param is not None:
+        origtext_value = wxr.wtp.node_to_wikitext(origtext_param).strip()
+        if ":" in origtext_value:
+            maybe_lang, _colon, _rest = origtext_value.partition(":")
+            maybe_lang = maybe_lang.strip()
+            if maybe_lang:
+                origtext_lang = maybe_lang
     expanded_node = wxr.wtp.parse(
         wxr.wtp.node_to_wikitext(node), expand_all=True
     )
@@ -137,6 +146,15 @@ def extract_quote_templates(
             "bold_roman_offsets",
         )
         break
+    if (
+        example_data.get("translation")
+        and origtext_lang is not None
+        and not origtext_lang.startswith("en")
+    ):
+        example_data["text"] = example_data["translation"]
+        example_data["bold_text_offsets"] = example_data.get(
+            "bold_translation_offsets", []
+        )
     clean_example_empty_data(example_data)
     return example_data
 

--- a/tests/test_en_example.py
+++ b/tests/test_en_example.py
@@ -98,3 +98,33 @@ class TestEnExample(TestCase):
                 }
             ],
         )
+
+    def test_quote_origtext_non_en_prefers_passage(self):
+        self.wxr.wtp.add_page(
+            "Template:quote-book",
+            10,
+            """<span class=\"h-quotation\">"
+            "<span class=\"e-quotation\" lang=\"de\">{{{origtext|}}}</span>"
+            "<span class=\"e-translation\">{{{passage|}}}</span>"
+            "</span>""",
+        )
+        page_data = parse_page(
+            self.wxr,
+            "lay",
+            """==English==
+===Verb===
+# gloss
+#: {{quote-book|author=Alice Stern|origtext=de:Eine ausgewachsene Henne '''legt''' Eier.|passage=A grown hen lays eggs.}}
+""",
+        )
+        self.assertEqual(
+            page_data[0]["senses"][0]["examples"],
+            [
+                {
+                    "text": "A grown hen lays eggs.",
+                    "english": "A grown hen lays eggs.",
+                    "translation": "A grown hen lays eggs.",
+                    "type": "example",
+                }
+            ],
+        )


### PR DESCRIPTION
## Summary
- detect the language code provided in quote template `origtext` parameters
- replace the example text with the `passage` translation when the original text is not English
- cover the new behaviour with a regression test for English extraction

## Testing
- PYTHONPATH=src pytest tests/test_en_example.py::TestEnExample::test_quote_origtext_non_en_prefers_passage


------
https://chatgpt.com/codex/tasks/task_e_68e4ae763cb48331a6dc229246d6d2d1